### PR TITLE
Fix ME Proxy failing to connect to AE2 cables on world reload and reverse placement order

### DIFF
--- a/src/main/java/com/forsteri/createappliedkinetics/content/meProxy/MEProxyBlock.java
+++ b/src/main/java/com/forsteri/createappliedkinetics/content/meProxy/MEProxyBlock.java
@@ -1,9 +1,38 @@
 package com.forsteri.createappliedkinetics.content.meProxy;
 
+import appeng.api.networking.GridHelper;
 import appeng.block.AEBaseEntityBlock;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
 
 public class MEProxyBlock extends AEBaseEntityBlock<MEProxyBlockEntity> {
     public MEProxyBlock(Properties props) {
         super(props);
+    }
+
+    @Override
+    public void onPlace(BlockState state, Level level, BlockPos pos, BlockState oldState, boolean movedByPiston) {
+        super.onPlace(state, level, pos, oldState, movedByPiston);
+        if (!level.isClientSide()) {
+            MEProxyBlockEntity be = getBlockEntity(level, pos);
+            if (be != null) {
+                GridHelper.onFirstTick(be, (nbe) -> nbe.scheduleReconnect());
+            }
+        }
+    }
+
+    @Override
+    public void neighborChanged(BlockState state, Level level, BlockPos pos, Block neighborBlock, BlockPos neighborPos, boolean movedByPiston) {
+        super.neighborChanged(state, level, pos, neighborBlock, neighborPos, movedByPiston);
+        if (!level.isClientSide()) {
+            MEProxyBlockEntity be = getBlockEntity(level, pos);
+            BlockEntity neighborBe = level.getBlockEntity(neighborPos);
+            if (be != null && neighborBe != null) {
+                GridHelper.onFirstTick(neighborBe, (nbe) -> be.scheduleReconnect());
+            }
+        }
     }
 }

--- a/src/main/java/com/forsteri/createappliedkinetics/content/meProxy/MEProxyBlockEntity.java
+++ b/src/main/java/com/forsteri/createappliedkinetics/content/meProxy/MEProxyBlockEntity.java
@@ -1,18 +1,82 @@
 package com.forsteri.createappliedkinetics.content.meProxy;
 
 import appeng.api.inventories.InternalInventory;
+import appeng.api.networking.GridHelper;
 import appeng.blockentity.grid.AENetworkedPoweredBlockEntity;
 import com.forsteri.createappliedkinetics.entry.Registration;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
 
+import java.util.EnumSet;
+
 public class MEProxyBlockEntity extends AENetworkedPoweredBlockEntity {
+    private boolean pendingReconnect = false;
+    private int reconnectCountdown = -1;
+
     public MEProxyBlockEntity(BlockEntityType<?> blockEntityType, BlockPos pos, BlockState blockState) {
         super(blockEntityType, pos, blockState);
         this.getMainNode().setIdlePowerUsage(0.0F);
+    }
+
+    @Override
+    public void onReady() {
+        super.onReady();
+        if (level != null && !level.isClientSide) {
+            pendingReconnect = true;
+            reconnectCountdown = 1;
+        }
+    }
+
+    public void scheduleReconnect() {
+        if (level == null || level.isClientSide || pendingReconnect) return;
+        pendingReconnect = true;
+        reconnectCountdown = 1;
+    }
+
+    public static void tick(Level level, BlockPos pos, BlockState state, MEProxyBlockEntity be) {
+        if (!be.pendingReconnect) return;
+
+        int connectableNeighbors = 0;
+        for (Direction dir : Direction.values()) {
+            if (GridHelper.getExposedNode(level, pos.relative(dir), dir.getOpposite()) != null) {
+                connectableNeighbors++;
+            }
+        }
+
+        int currentConnections = 0;
+        if (be.getMainNode().getNode() != null) {
+            currentConnections = be.getMainNode().getNode().getConnections().size();
+        }
+
+        if (connectableNeighbors == 0) {
+            be.reconnectCountdown++;
+            if (be.reconnectCountdown > 40) {
+                be.pendingReconnect = false;
+                be.reconnectCountdown = -1;
+            }
+            return;
+        }
+
+        if (currentConnections < connectableNeighbors) {
+
+            be.getMainNode().setExposedOnSides(EnumSet.noneOf(Direction.class));
+            ((ServerLevel) level).getServer().execute(() -> {
+                if (!be.isRemoved()) {
+                    be.pendingReconnect = false;
+                    be.reconnectCountdown = -1;
+                    be.getMainNode().setExposedOnSides(EnumSet.allOf(Direction.class));
+                }
+            });
+        } else {
+            be.pendingReconnect = false;
+            be.reconnectCountdown = -1;
+        }
     }
 
     @Override

--- a/src/main/java/com/forsteri/createappliedkinetics/content/meProxy/MEProxyInventoryHandler.java
+++ b/src/main/java/com/forsteri/createappliedkinetics/content/meProxy/MEProxyInventoryHandler.java
@@ -113,7 +113,7 @@ public class MEProxyInventoryHandler implements IItemHandler, IFluidHandler {
 
     @Override
     public int getSlots() {
-        return getItemKeys().size() + 16; // Allocate 16 slots for input
+        return getItemKeys().size() + 16;
     }
 
     @NotNull
@@ -166,10 +166,4 @@ public class MEProxyInventoryHandler implements IItemHandler, IFluidHandler {
     public boolean isItemValid(int slot, @NotNull ItemStack stack) {
         return insertItem(slot, stack, true).getCount() == 0;
     }
-
-//    @Override
-//    public void setStackInSlot(int slot, ItemStack stack) {
-//
-//
-//    }
 }

--- a/src/main/java/com/forsteri/createappliedkinetics/entry/Registration.java
+++ b/src/main/java/com/forsteri/createappliedkinetics/entry/Registration.java
@@ -104,9 +104,11 @@ public class Registration {
             .register();
 
     public static BlockEntityEntry<MEProxyBlockEntity> meProxyBlockEntity = CreateAppliedKinetics.REGISTERATE.blockEntity("me_proxy", MEProxyBlockEntity::new)
-            .validBlock(meProxyBlock)
-            .onRegister(blockEntityType -> meProxyBlock.get().setBlockEntity(MEProxyBlockEntity.class, blockEntityType, (p_155253_, p_155254_, p_155255_, p_155256_) -> {}, (p_155253_, p_155254_, p_155255_, p_155256_) -> {}))
-            .register();
+        .validBlock(meProxyBlock)
+        .onRegister(blockEntityType -> meProxyBlock.get().setBlockEntity(MEProxyBlockEntity.class, blockEntityType,
+            null,
+            MEProxyBlockEntity::tick))
+        .register();
 
     private static final DeferredRegister<CreativeModeTab> REGISTER
             = DeferredRegister.create(Registries.CREATIVE_MODE_TAB, CreateAppliedKinetics.MODID);
@@ -117,16 +119,6 @@ public class Registration {
                             .title(Component.translatable("itemGroup.createappliedkinetics"))
                             .withTabsBefore(AllCreativeModeTabs.PALETTES_CREATIVE_TAB.getId())
                             .icon(() -> energyProviderBlock.get().asItem().getDefaultInstance())
-//                            .displayItems(
-//                                    (parameters, output) ->
-//                                            output.acceptAll(
-//                                                    CreateAppliedKinetics.REGISTERATE.getAll(Registries.ITEM).stream().filter(
-//                                                            itemRegistryEntry -> !(itemRegistryEntry.get() instanceof SequencedAssemblyItem)
-//                                                    ).map(
-//                                                            regObj -> new ItemStack(regObj.get())
-//                                                    ).toList()
-//                                            )
-//                            )
                             .build());
 
     private static final DeferredRegister<MapCodec<? extends ICondition>> CONDITION_REGISTER


### PR DESCRIPTION
Previously, the ME Proxy block entity did not account for AE2's network initialization timing, causing two bugs:

1. All connected cables would disconnect on every world/server reload, requiring the proxy to be broken and replaced to restore connections.

2. AE2 cables placed adjacent to an existing ME Proxy would not connect unless the proxy was placed first.

The fix adds a tick-based reconnect system to MEProxyBlockEntity that monitors for missing connections after initialization and uses setExposedOnSides() to force AE2 to rediscover neighbors only when connections are actually missing. MEProxyBlock overrides onPlace() and neighborChanged() using GridHelper.onFirstTick() to defer reconnection until neighboring block entities are fully initialized. The server-side ticker is registered in Registration.java, replacing the previously empty lambda.